### PR TITLE
Feat/accueil component

### DIFF
--- a/UnePiece/src/main/java/UnePiece/controller/PartieRestController.java
+++ b/UnePiece/src/main/java/UnePiece/controller/PartieRestController.java
@@ -88,6 +88,18 @@ public class PartieRestController {
 		return partiesDTO;
 	}
 
+	@GetMapping("/leaderboard")
+	public List<PartieResponse> findLeaderboard() {
+		List<Partie> parties = daoPartie.findAllByOrderByDureeDesc();
+		List<PartieResponse> partiesDTO = new ArrayList<PartieResponse>();
+		for (Partie p : parties) {
+			PartieResponse partieDTO = new PartieResponse();
+			BeanUtils.copyProperties(p, partieDTO);
+			partiesDTO.add(partieDTO);
+		}
+		return partiesDTO;
+	}
+
 	@PostMapping
 	public PartieResponse insert(@RequestBody Partie partie, BindingResult result) {
 		/*
@@ -97,6 +109,13 @@ public class PartieRestController {
 		 * "La partie n'est pas valide...");
 		 * }
 		 */
+
+		Optional<Partie> opt = daoPartie.findByIdJoueur(partie.getJoueur().getId());
+		if(opt.isPresent()) {
+			Partie anciennePartie = opt.get();
+			anciennePartie.setTermine(true);
+			daoPartie.save(anciennePartie);
+		}
 		daoPartie.save(partie);
 		PartieResponse partieDTO = new PartieResponse();
 		BeanUtils.copyProperties(partie, partieDTO);

--- a/UnePiece/src/main/java/UnePiece/dao/IDAOPartie.java
+++ b/UnePiece/src/main/java/UnePiece/dao/IDAOPartie.java
@@ -1,5 +1,6 @@
 package UnePiece.dao;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface IDAOPartie extends JpaRepository<Partie,Integer> {
 	
 	@Query("SELECT p FROM Partie p JOIN FETCH p.membres WHERE p.joueur.id = ?1 and p.termine = false")
 	Optional<Partie> findByIdJoueurWithMembres(Integer id);
+
+	List<Partie> findAllByOrderByDureeDesc();
 }

--- a/UnePiece/src/main/java/UnePiece/dto/PartieResponse.java
+++ b/UnePiece/src/main/java/UnePiece/dto/PartieResponse.java
@@ -5,10 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import UnePiece.model.Ile;
+import UnePiece.model.Joueur;
 import UnePiece.model.Navire;
 
 public class PartieResponse {
-	
+
 	private Integer id;
 	private LocalDate dateDebut;
 	private boolean termine;
@@ -18,10 +19,20 @@ public class PartieResponse {
 	private Navire navire;
 	private Ile ile;
 	private int joursRestants;
+	private Joueur joueur;
+
+	public Joueur getJoueur() {
+		return joueur;
+	}
+
+	public void setJoueur(Joueur joueur) {
+		this.joueur = joueur;
+	}
 
 	public Integer getId() {
 		return id;
 	}
+
 	public void setId(Integer id) {
 		this.id = id;
 	}
@@ -33,49 +44,61 @@ public class PartieResponse {
 	public void setJoursRestants(int joursRestants) {
 		this.joursRestants = joursRestants;
 	}
+
 	public LocalDate getDateDebut() {
 		return dateDebut;
 	}
+
 	public void setDateDebut(LocalDate dateDebut) {
 		this.dateDebut = dateDebut;
 	}
+
 	public boolean isTermine() {
 		return termine;
 	}
+
 	public void setTermine(boolean termine) {
 		this.termine = termine;
 	}
+
 	public Integer getTresor() {
 		return tresor;
 	}
+
 	public void setTresor(Integer tresor) {
 		this.tresor = tresor;
 	}
+
 	public Integer getDuree() {
 		return duree;
 	}
+
 	public void setDuree(Integer duree) {
 		this.duree = duree;
 	}
+
 	public List<MembreResponse> getMembres() {
 		return membres;
 	}
+
 	public void setMembres(List<MembreResponse> membres) {
 		this.membres = membres;
 	}
+
 	public Navire getNavire() {
 		return navire;
 	}
+
 	public void setNavire(Navire navire) {
 		this.navire = navire;
 	}
+
 	public Ile getIle() {
 		return ile;
 	}
+
 	public void setIle(Ile ile) {
 		this.ile = ile;
 	}
-	
-	
-	
+
 }

--- a/UnePieceAngular/src/app/accueil/accueil.component.html
+++ b/UnePieceAngular/src/app/accueil/accueil.component.html
@@ -3,7 +3,7 @@
 <button class="btn btn-success" (click)="continueGame()">
   Démarrer partie <i class="bi bi-plus-circle"></i>
 </button>
-
+<button (click)="newGame()"> NEW GAME TEST </button>
 <div id="container">
   <div id="partieEnCours" *ngIf="partie">
     <table>  Partie en cours
@@ -18,8 +18,8 @@
         <td>{{partie.dateDebut}}</td>
         <td>{{partie.duree}}</td>
         <td *ngIf="partie.membres[0]">{{partie.membres[0].pirate?.nom}}</td>
-        <td>{{partie.ile?.mer}}</td>
-        <td>{{partie.ile}}</td>
+        <td *ngIf="partie.ile!.mer">{{partie.ile!.mer}}</td>
+        <td>{{partie.ile!.nom}}</td>
      </tr>
     
     </table>
@@ -31,11 +31,13 @@
         <th>Joueur</th>
         <th>Score</th>
         <th>Date</th>
+        <th>Terminé ?</th>
      </tr>
      <tr *ngFor="let p of parties">
-        <td>NOM_JOUEUR</td>
+        <td>{{p.joueur!.login}}</td>
         <td>{{p.duree}}</td>
         <td>{{p.dateDebut}}</td>
+        <td>{{p.termine}}</td>
      </tr>
     </table>
   </div>

--- a/UnePieceAngular/src/app/accueil/accueil.component.html
+++ b/UnePieceAngular/src/app/accueil/accueil.component.html
@@ -5,15 +5,21 @@
 </button>
 
 <div id="container">
-  <div id="partieEnCours">
+  <div id="partieEnCours" *ngIf="partie">
     <table>  Partie en cours
      <tr>
         <th>Début</th>
         <th>Score</th>
+        <th>Capitaine</th>
+        <th>Mer</th>
+        <th>Ile</th>
      </tr>
      <tr>
-        <td>2023-10-10</td>
-        <td>29</td>
+        <td>{{partie.dateDebut}}</td>
+        <td>{{partie.duree}}</td>
+        <td *ngIf="partie.membres[0]">{{partie.membres[0].pirate?.nom}}</td>
+        <td>{{partie.ile?.mer}}</td>
+        <td>{{partie.ile}}</td>
      </tr>
     
     </table>

--- a/UnePieceAngular/src/app/accueil/accueil.component.ts
+++ b/UnePieceAngular/src/app/accueil/accueil.component.ts
@@ -25,9 +25,12 @@ export class AccueilComponent {
   ) {
     this.joueur = this.authService.getUtilisateur() as Joueur;
     this.partie = this.partieService.getPartie();
-    if (this.partie) {
-      this.partie.joueur = this.joueur;
-    }
+     if (!this.partie) {
+      this.partieService.findByIdJoueurWithMembres(this.joueur.id).subscribe(resp =>{
+        this.partie=resp;
+      })
+     } 
+    console.log("this.partie :>>",this.partie)
     this.partieService.findAll().subscribe((resp) => {
       this.parties = resp;
       console.log('this.parties :>> ', this.parties);

--- a/UnePieceAngular/src/app/accueil/accueil.component.ts
+++ b/UnePieceAngular/src/app/accueil/accueil.component.ts
@@ -21,17 +21,19 @@ export class AccueilComponent {
     private authService: AuthService,
     private ileService: IleService,
     private bateauService: BateauService,
-    private navireService: NavireService,
+    private navireService: NavireService
   ) {
     this.joueur = this.authService.getUtilisateur() as Joueur;
     this.partie = this.partieService.getPartie();
-     if (!this.partie) {
-      this.partieService.findByIdJoueurWithMembres(this.joueur.id).subscribe(resp =>{
-        this.partie=resp;
-      })
-     } 
-    console.log("this.partie :>>",this.partie)
-    this.partieService.findAll().subscribe((resp) => {
+    if (!this.partie) {
+      this.partieService
+        .findByIdJoueurWithMembres(this.joueur.id)
+        .subscribe((resp) => {
+          this.partie = resp;
+          console.log('this.partie :>>', this.partie);
+        });
+    }
+    this.partieService.findLeaderboard().subscribe((resp) => {
       this.parties = resp;
       console.log('this.parties :>> ', this.parties);
     });
@@ -69,13 +71,12 @@ export class AccueilComponent {
     this.partie.dateDebut = new Date(Date.now()).toISOString().substr(0, 10);
     this.partie.forceTotale = 0;
     this.partie.joursRestants = 0;
-    
 
     this.ileService.findById(1).subscribe((resp) => {
       if (this.partie) {
         this.partie.ile = resp;
         this.partie.joursRestants = this.partie.ile.attente;
-        this.bateauService.findById(1).subscribe(bateau =>{
+        this.bateauService.findById(1).subscribe((bateau) => {
           let newNavire: Navire = new Navire();
           newNavire.bateau = bateau;
           newNavire.robustesse = bateau.robustesse;
@@ -92,8 +93,8 @@ export class AccueilComponent {
               }
               this.router.navigate(['/start']);
             });
-          })
-        })
+          });
+        });
       }
     });
   }

--- a/UnePieceAngular/src/app/ile/ile.component.ts
+++ b/UnePieceAngular/src/app/ile/ile.component.ts
@@ -118,7 +118,8 @@ export class IleComponent {
     ) {
       membre.pv += 1;
       this.membreService.update(membre).subscribe();
-      this.partie.joursRestants!--;
+      // this.partie.joursRestants!--;
+      this.nextDay();
       console.log(membre, ' a été reposé');
     } else {
       console.log('Le pirate a déjà ses PV au max');
@@ -150,7 +151,8 @@ export class IleComponent {
       this.membreService.create(newMembre).subscribe((resp) => {
         this.partie.membres.push(resp);
         this.partieService.getForceTotale();
-        this.partie.joursRestants!--;
+        // this.partie.joursRestants!--;
+        this.nextDay();
         this.partieService.update(this.partie).subscribe(() => {
           this.partieService.savePartieInStorage(this.partie);
         });
@@ -187,7 +189,8 @@ export class IleComponent {
       this.navireService.create(newNavire).subscribe((resp) => {
         this.navire = resp;
         this.partie.navire = this.navire;
-        this.partie.joursRestants!--;
+        // this.partie.joursRestants!--;
+        this.nextDay();
         this.partieService.update(this.partie).subscribe(() => {
           this.partieService.savePartieInStorage(this.partie);
         });
@@ -215,7 +218,8 @@ export class IleComponent {
         console.log('Le navire a déjà sa robustesse au maximum');
       }
       this.navireService.update(this.navire).subscribe(() => {
-        this.partie.joursRestants!--;
+        // this.partie.joursRestants!--;
+        this.nextDay();
         this.partieService.update(this.partie).subscribe(() => {
           this.partieService.savePartieInStorage(this.partie);
         });
@@ -226,9 +230,9 @@ export class IleComponent {
 
   nextDay() {
     this.partie.joursRestants!--;
+    (this.partie.duree as number) += 1;
     this.partieService.update(this.partie).subscribe(() => {
       this.partieService.savePartieInStorage(this.partie);
-      (this.partie.duree as number) += 1;
     });
   }
 

--- a/UnePieceAngular/src/app/partie.service.ts
+++ b/UnePieceAngular/src/app/partie.service.ts
@@ -79,6 +79,10 @@ export class PartieService {
     return this.http.get<Partie>(environment.apiUrl + '/partie/joueur/' + id);
   }
 
+  findLeaderboard(): Observable<Partie[]> {
+    return this.http.get<Partie[]>(environment.apiUrl + '/partie/leaderboard');
+  }
+
   findByIdJoueurWithMembres(id?: number): Observable<Partie> {
     return this.http.get<Partie>(
       environment.apiUrl + '/partie/joueur/' + id + '/membres'

--- a/UnePieceAngular/src/app/trajet/trajet.component.html
+++ b/UnePieceAngular/src/app/trajet/trajet.component.html
@@ -1,5 +1,5 @@
 <div class="card-header text-white bg-primary">Trajet en cours</div>
-<p>Nrb jour restant : {{ partie.ile?.attente }}</p>
+<p>Jours restants : {{partie.joursRestants}}</p>
 <br><br><br>
 
 <action></action>
@@ -8,4 +8,4 @@
 <stat-equipage></stat-equipage>
 <br><br><br>
 
-<button (click)="Suite()">Jour Suivant</button>
+<button (click)="suite()">Jour Suivant</button>

--- a/UnePieceAngular/src/app/trajet/trajet.component.ts
+++ b/UnePieceAngular/src/app/trajet/trajet.component.ts
@@ -8,24 +8,25 @@ import { IleService } from '../ile.service';
 @Component({
   selector: 'app-trajet',
   templateUrl: './trajet.component.html',
-  styleUrls: ['./trajet.component.css']
+  styleUrls: ['./trajet.component.css'],
 })
 export class TrajetComponent {
-tpsTrajetRestant: number;
-joueur!: Joueur;
-partie!: Partie;
-ile?: Ile;
+  //tpsTrajetRestant: number;
+  joueur!: Joueur;
+  partie!: Partie;
+  //ile?: Ile;
 
   constructor(
     private router: Router,
     private partieService: PartieService,
-    private ileService: IleService,
-    private authService: AuthService,
+    //private ileService: IleService,
+    private authService: AuthService
   ) {
-      this.partie = this.partieService.getPartie() as Partie;
-      this.tpsTrajetRestant = this.partieService.getPartie()?.ile?.attente as number;
+    this.joueur = this.authService.getUtilisateur() as Joueur;
+    this.partie = this.partieService.getPartie() as Partie;
+    //this.tpsTrajetRestant = this.partieService.getPartie()?.ile?.attente as number;
 
-      /*
+    /*
       this.joueur = this.authService.getUtilisateur() as Joueur;
       if(this.joueur != undefined){
         this.partieService.findByIdJoueur(this.joueur.id).subscribe(resp => {
@@ -36,10 +37,27 @@ ile?: Ile;
       */
   }
 
+  suite() {
+    if (this.partie.joursRestants! > 1) {
+      this.partie.joursRestants!--;
+      this.partieService.update(this.partie).subscribe(() => {
+        this.partieService.savePartieInStorage(this.partie);
+      });
+    } else {
+      this.partie.joursRestants = this.partie.ile?.attente;
+      this.partieService.update(this.partie).subscribe(() => {
+        this.partieService.savePartieInStorage(this.partie);
+        this.router.navigate(['/ile']);
+      });
+    }
+  }
+
+  /*
   Suite(){
     if(this.tpsTrajetRestant > 1){
       this.tpsTrajetRestant--;            
       (this.partie.ile!.attente as number) = this.tpsTrajetRestant;
+
       this.partieService.update(this.partie).subscribe(() => {
         this.partieService.savePartieInStorage(this.partie);
         this.router.navigate(['/trajet/']);
@@ -56,5 +74,5 @@ ile?: Ile;
       });      
     }
   }
-
+  */
 }


### PR DESCRIPTION
### Nouvel attribut joursRestants dans partie

- Permet de facilement reprendre où on en était quand on reprend une partie en cours. 

- J'ai fix le trajet component, plutôt que créer un attribut tpsRestant on utilise maintenant cet attribut. C'est bien plus propre, ça évite d'avoir à aller rechercher l'attente de l'ile etc. Aussi il y avait un ileService.findById pour récupérer l'ile, mais on l'a déjà dans partie ^^

- On a réparé la méthode nextDay() de ile.component pour correctement set la durée avant d'update la partie en base.

### Affichage du leaderboard et de la partie en cours sur l'accueil

- Nouvelle requête HTTP dans daoPartie : cette requête return les parties avec le meilleur score. On voulait afficher le top10 mais pour l'instant on les return toutes. On l'appelle grâce à la méthode findLeaderboard() dans le partie service.

- On a ajouté l'attribut joueur au partieDTO pour pouvoir afficher le pseudo (actuellement le login) des joueurs dans le leaderboard.

- Affichage des infos de la partie en cours si partie en cours.

- Quand on crée une nouvelle partie, cela set automatiquement l'ancienne à termine=true (grâce au findByIdJoueur), dans la méthode create() du PartieRestController

- Quand on arrive sur accueil, auparavant on ne faisait que partieService.getPartie(), or la partie n'est pas set dans le partie service quand on vient de se co tant qu'on n'a pas fait continueGame() ou newGame() -> maintenant, dans le constructeur du accueil component, si getPartie() renvoie undefined, on fait un partieService.findByIdJoueur pour aller chercher la partie en base

